### PR TITLE
Change crafts to use groups when available

### DIFF
--- a/cobble.lua
+++ b/cobble.lua
@@ -105,9 +105,9 @@ minetest.register_node("more_chests:cobble", {
 minetest.register_craft({
 	output = 'more_chests:cobble',
 	recipe = {
-		{'default:wood','default:cobble','default:wood'},
+		{'group:wood','default:cobble','group:wood'},
 		{'default:cobble','default:steel_ingot','default:cobble'},
-		{'default:wood','default:cobble','default:wood'}
+		{'group:wood','default:cobble','group:wood'}
 	}
 })
 

--- a/dropbox.lua
+++ b/dropbox.lua
@@ -101,9 +101,9 @@ minetest.register_node("more_chests:dropbox", {
 minetest.register_craft({
 	output = 'more_chests:dropbox',
 	recipe = {
-		{'default:wood','','default:wood'},
-		{'default:wood','default:steel_ingot','default:wood'},
-		{'default:wood','default:wood','default:wood'}
+		{'group:wood','','group:wood'},
+		{'group:wood','default:steel_ingot','group:wood'},
+		{'group:wood','group:wood','group:wood'}
 	}
 })
 

--- a/secret.lua
+++ b/secret.lua
@@ -121,9 +121,9 @@ minetest.register_node("more_chests:secret", {
 minetest.register_craft({
 	output = 'more_chests:secret',
 	recipe = {
-		{'default:wood','default:cobble','default:wood'},
-		{'default:wood','default:steel_ingot','default:wood'},
-		{'default:wood','default:wood','default:wood'}
+		{'group:wood','default:cobble','group:wood'},
+		{'group:wood','default:steel_ingot','group:wood'},
+		{'group:wood','group:wood','group:wood'}
 	}
 })
 

--- a/shared.lua
+++ b/shared.lua
@@ -127,9 +127,9 @@ minetest.register_node("more_chests:shared", {
 minetest.register_craft({
 	output = 'more_chests:shared',
 	recipe = {
-		{'default:wood','default:leaves','default:wood'},
-		{'default:wood','default:steel_ingot','default:wood'},
-		{'default:wood','default:wood','default:wood'}
+		{'group:wood','group:leaves','group:wood'},
+		{'group:wood','default:steel_ingot','group:wood'},
+		{'group:wood','group:wood','group:wood'}
 	}
 })
 

--- a/wifi.lua
+++ b/wifi.lua
@@ -39,9 +39,9 @@ minetest.register_node("more_chests:wifi", {
 minetest.register_craft({
 	output = 'more_chests:wifi',
 	recipe = {
-		{'default:wood','default:mese','default:wood'},
-		{'default:wood','default:steel_ingot','default:wood'},
-		{'default:wood','default:wood','default:wood'}
+		{'group:wood','default:mese','group:wood'},
+		{'group:wood','default:steel_ingot','group:wood'},
+		{'group:wood','group:wood','group:wood'}
 	}
 })
 


### PR DESCRIPTION
This allows crafting using all kinds of woods instead of default wood
and also using all kinds of leaves instead of default leaves for shared
chest.