### PR TITLE
Refuse take/put in wifi chest if there is no more_chest:wifi node near

### DIFF
--- a/models/wifi.lua
+++ b/models/wifi.lua
@@ -89,11 +89,11 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info)
-	if inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi" then
+	if (inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi") and not minetest.is_creative_enabled(player:get_player_name()) then
 		local pos = player:get_pos()
 		local witem = player:get_wielded_item()
 		local def = witem and witem:get_definition()
-		local range = def and def.range or (minetest.is_creative_enabled(player:get_player_name()) and 10 or 4)
+		local range = def and def.range or 4
 		local chest = minetest.find_node_near(pos, range, "more_chests:wifi")
 		if not chest then
 			return 0

--- a/models/wifi.lua
+++ b/models/wifi.lua
@@ -92,8 +92,7 @@ minetest.register_allow_player_inventory_action(function(player, action, invento
 	if inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi" then
 		local pos = player:get_pos()
 		local witem = player:get_wielded_item()
-		local iname = witem and witem:get_name()
-		local def = iname and minetest.registered_items[iname]
+		local def = witem and witem:get_definition()
 		local range = def and def.range or (minetest.is_creative_enabled(player:get_player_name()) and 10 or 4)
 		local chest = minetest.find_node_near(pos, range, "more_chests:wifi")
 		if not chest then

--- a/models/wifi.lua
+++ b/models/wifi.lua
@@ -87,3 +87,17 @@ minetest.register_on_joinplayer(function(player)
 	local inv = player:get_inventory()
 	inv:set_size("more_chests:wifi", 8*4)
 end)
+
+minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info)
+	if inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi" then
+		local pos = player:get_pos()
+		local witem = player:get_wielded_item()
+		local iname = witem and witem:get_name()
+		local def = iname and minetest.registered_items[iname]
+		local range = def and def.range or (minetest.is_creative_enabled(player:get_player_name()) and 10 or 4)
+		local chest = minetest.find_node_near(pos, range, "more_chests:wifi")
+		if not chest then
+			return 0
+		end
+	end
+end)

--- a/models/wifi.lua
+++ b/models/wifi.lua
@@ -92,10 +92,13 @@ minetest.register_allow_player_inventory_action(function(player, action, invento
 	if (inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi")
 			and not minetest.is_creative_enabled(player:get_player_name()) then
 		local pos = player:get_pos()
-		local witem = player:get_wielded_item()
-		local def = witem and witem:get_definition()
+		pos.y = pos.y + player:get_properties().eye_height
+
+		local def = player:get_wielded_item():get_definition()
 		local range = def and def.range or 4
-		local chest = minetest.find_node_near(pos, range, "more_chests:wifi")
+		-- Additional tolerance to reach the node corner diagonally
+		-- Also allows minor eye offsets to be used
+		local chest = minetest.find_node_near(pos, range + 1, "more_chests:wifi")
 		if not chest then
 			return 0
 		end

--- a/models/wifi.lua
+++ b/models/wifi.lua
@@ -89,7 +89,8 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_allow_player_inventory_action(function(player, action, inventory, inventory_info)
-	if (inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi") and not minetest.is_creative_enabled(player:get_player_name()) then
+	if (inventory_info.to_list == "more_chests:wifi" or inventory_info.from_list == "more_chests:wifi")
+			and not minetest.is_creative_enabled(player:get_player_name()) then
 		local pos = player:get_pos()
 		local witem = player:get_wielded_item()
 		local def = witem and witem:get_definition()


### PR DESCRIPTION
This PR prevents abusing an exploit that allows to access `current_player:more_chests:wifi` *inventory* using CSM at any time even if there is no `more_chests:wifi` *node* near.

## How to test
1. Place `more_chests:wifi` node somewhere in the world.
2. Try to put/take something in/from the chest by the normal way. They will be put/taken freely.
3. Go away from the chest or break it, then access `current_player:more_chests:wifi` inventory in any convenient way ([example CSM](https://github.com/zmv7/minetest-csm-cinv))
4. Any items won't be put/taken in/from `current_player:more_chests:wifi` if this PR is **applied**