### PR TITLE
fixes: shared chest fails to open for users with hyphen in their name #32

### DIFF
--- a/models/shared.lua
+++ b/models/shared.lua
@@ -25,7 +25,7 @@ local function check_privs(meta, player)
 	local shared = " " .. meta:get_string("shared") .. " "
 	if name == meta:get_string("owner") then
 		return true
-	elseif shared:find(" " .. name .. " ") then
+	elseif shared:find(" " .. name .. " ",1,true) then
 		return true
 	else
 		return false

--- a/models/shared.lua
+++ b/models/shared.lua
@@ -25,7 +25,7 @@ local function check_privs(meta, player)
 	local shared = " " .. meta:get_string("shared") .. " "
 	if name == meta:get_string("owner") then
 		return true
-	elseif shared:find(" " .. name .. " ",1,true) then
+	elseif shared:find(" " .. name .. " ", 1, true) then
 		return true
 	else
 		return false


### PR DESCRIPTION
the find function interprets the hyphen as a search pattern. this change stops the find function from interpreting the playername.
This may have caused other issues as well.